### PR TITLE
凸報告でkillが先頭以外でも動くように正規表現を変更

### DIFF
--- a/dist/client/report/cancel.js
+++ b/dist/client/report/cancel.js
@@ -189,7 +189,7 @@ var killConfirm = function (msg) { return __awaiter(void 0, void 0, void 0, func
     var content;
     return __generator(this, function (_a) {
         content = util.Format(msg.content);
-        if (!/^k/i.test(content))
+        if (!/^k|kill/i.test(content))
             return [2];
         lapAndBoss.Previous();
         return [2];

--- a/dist/client/report/status.js
+++ b/dist/client/report/status.js
@@ -137,7 +137,7 @@ var saveHistory = function (num_cell, over_cell, hist_cell) { return __awaiter(v
 var statusUpdate = function (num_cell, over_cell, content) {
     var num = Number(num_cell.getValue());
     var over = over_cell.getValue();
-    if (/^k/i.test(content)) {
+    if (/^k|kill/i.test(content)) {
         lapAndBoss.Next();
         if (over) {
             over_cell.setValue();

--- a/src/client/report/cancel.ts
+++ b/src/client/report/cancel.ts
@@ -167,7 +167,7 @@ const feedback = (num_cell: any, over_cell: any, user: Discord.User) => {
 const killConfirm = async (msg: Discord.Message) => {
   const content = util.Format(msg.content)
   // ボスを倒していなければ終了
-  if (!/^k/i.test(content)) return
+  if (!/^k|kill/i.test(content)) return
 
   // 前のボスに戻す
   lapAndBoss.Previous()

--- a/src/client/report/status.ts
+++ b/src/client/report/status.ts
@@ -97,7 +97,7 @@ const statusUpdate = (num_cell: any, over_cell: any, content: string) => {
   const over = over_cell.getValue()
 
   // ボスを倒した場合はtrue、倒していない場合はfalse
-  if (/^k/i.test(content)) {
+  if (/^k|kill/i.test(content)) {
     // 次のボスに進める
     lapAndBoss.Next()
 


### PR DESCRIPTION
#170 `/^k|kill/i.test(content)`